### PR TITLE
FIX: a delegator was banned from proxy regsiter with keeping binding …

### DIFF
--- a/x/staking/handler_vote.go
+++ b/x/staking/handler_vote.go
@@ -47,8 +47,7 @@ func handleMsgBindProxy(ctx sdk.Context, msg types.MsgBindProxy, k keeper.Keeper
 
 	finalTokens := proxyDelegator.TotalDelegatedTokens.Add(proxyDelegator.Tokens)
 
-	err := k.UpdateVotes(ctx, proxyDelegator.DelegatorAddress, finalTokens)
-	if err != nil {
+	if err := k.UpdateVotes(ctx, proxyDelegator.DelegatorAddress, finalTokens); err != nil {
 		return types.ErrInvalidDelegation(types.DefaultCodespace, proxyDelegator.DelegatorAddress.String()).Result()
 	}
 
@@ -84,10 +83,11 @@ func regProxy(ctx sdk.Context, proxyAddr sdk.AccAddress, k keeper.Keeper) sdk.Re
 	if !found {
 		return types.ErrNoDelegationVote(types.DefaultCodespace, proxyAddr.String()).Result()
 	}
-
 	if proxy.IsProxy {
 		return types.ErrAlreadyProxied(types.DefaultCodespace, proxyAddr.String()).Result()
-
+	}
+	if len(proxy.ProxyAddress) != 0 {
+		return types.ErrAlreadyBinded(types.DefaultCodespace, proxy.DelegatorAddress.String()).Result()
 	}
 
 	proxy.RegProxy(true)

--- a/x/staking/keeper/proxy_test.go
+++ b/x/staking/keeper/proxy_test.go
@@ -39,7 +39,7 @@ func TestVoteValidatorsAndWithdrawVote(t *testing.T) {
 		require.True(t, vote.GT(lastVotes), vote)
 	}
 
-	// standarlize
+	// standardize
 	sVals := valsNew.Standardize()
 	require.NotNil(t, sVals)
 	r, err := sVals.MarshalYAML()

--- a/x/staking/types/errors.go
+++ b/x/staking/types/errors.go
@@ -272,3 +272,10 @@ func ErrTargetValsDuplicate(codespace sdk.CodespaceType) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidVote,
 		"failed. duplicate target validators")
 }
+
+// ErrAlreadyBinded returns an error when a delegator keeps binding a proxy before proxy register
+func ErrAlreadyBinded(codespace sdk.CodespaceType, delAddr string) sdk.Error {
+	return sdk.NewError(codespace, CodeInvalidProxy,
+		"failed. %s has already binded a proxy. it's necessary to unbind before proxy register",
+		delAddr)
+}


### PR DESCRIPTION
…before (#49)

* FIX: ODEX-328 delegator was banned from binding proxy again before unbinding

* FIX: ODEX-329 delegator was banned from proxy regsiter with keeping binding before

* Rollback: allowance of binding again without unbinding

* FINSH: add ut to limit proxy register of a binded delegator

Co-authored-by: Zhong Qiu <36867992+zhongqiuwood@users.noreply.github.com>

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
