### PR TITLE
Modify circleci shell  to increase merge coverage rate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,14 +59,27 @@ jobs:
           name: Run tests with coverage and upload codecov
           command: |
             set -ex
-            echo "--> Run tests with coverage:"
+            excluded_packages_expr="(okchain/x/.*/client)|(x/simulation)|(x/backend)"
+            included_packages=("./app" "./x/common" "./x/dex" "./x/distribution" "./x/gov" "./x/order" "./x/params" "./x/staking" "./x/token" "./x/upgrade")
+
             export VERSION="$(git describe --tags --long | sed 's/v\(.*\)/\1/')"
             export GO111MODULE=on
             mkdir -p /tmp/logs /tmp/workspace/profiles
-            for pkg in $(go list ./... | grep -v -e '/simulation' -e '/backend'  | circleci tests split); do
-              id=$(echo "$pkg" | sed 's|[/.]|_|g')
-              go test -mod=readonly -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic -tags='ledger test_ledger_mock' "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
+
+            echo "--> Run tests with coverage:"
+            for pkg in ${included_packages[@]}; do
+                package_lines=`go list ${pkg}/... | grep -v -E "${excluded_packages_expr}"`
+                echo "${package_lines[@]}"
+                cover_pkgs=`echo ${package_lines[@]} | sed 's/ /,/g'`
+                packages=`echo ${package_lines[@]}`
+                id=`echo "${package_lines}" | head -n 1 | sed 's|[/.]|_|g'`
+                go test -mod=readonly -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -coverpkg=${cover_pkgs} -covermode=atomic  -tags='ledger test_ledger_mock' ${packages} | tee "/tmp/logs/$id-$RANDOM.log"
             done
+
+#            for pkg in $(go list ./... | grep -v -E "${excluded_packages_expr}" | circleci tests split); do
+#              id=$(echo "$pkg" | sed 's|[/.]|_|g')
+#              go test -mod=readonly -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic -tags='ledger test_ledger_mock' "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
+#            done
 
             echo "--> Gather coverage:"
             ls /tmp/workspace/profiles/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,11 +76,6 @@ jobs:
               go test -mod=readonly -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -coverpkg=${cover_pkgs} -covermode=atomic  -tags='ledger test_ledger_mock' ${packages} | tee "/tmp/logs/$id-$RANDOM.log"
             done
 
-#            for pkg in $(go list ./... | grep -v -E "${excluded_packages_expr}" | circleci tests split); do
-#              id=$(echo "$pkg" | sed 's|[/.]|_|g')
-#              go test -mod=readonly -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic -tags='ledger test_ledger_mock' "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
-#            done
-
             echo "--> Gather coverage:"
             ls /tmp/workspace/profiles/
             echo "mode: atomic" > coverage.txt
@@ -98,6 +93,12 @@ jobs:
 
             echo "--> upload codecov:"
             bash <(curl -s https://codecov.io/bash) -f coverage.txt
+
+
+#            for pkg in $(go list ./... | grep -v -E "${excluded_packages_expr}" | circleci tests split); do
+#              id=$(echo "$pkg" | sed 's|[/.]|_|g')
+#              go test -mod=readonly -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -covermode=atomic -tags='ledger test_ledger_mock' "$pkg" | tee "/tmp/logs/$id-$RANDOM.log"
+#            done
 #      - persist_to_workspace:
 #          root: /tmp/workspace
 #          paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,21 +59,21 @@ jobs:
           name: Run tests with coverage and upload codecov
           command: |
             set -ex
-            excluded_packages_expr="(okchain/x/.*/client)|(x/simulation)|(x/backend)"
-            included_packages=("./app" "./x/common" "./x/dex" "./x/distribution" "./x/gov" "./x/order" "./x/params" "./x/staking" "./x/token" "./x/upgrade")
-
+            echo "--> Run tests with coverage:"
             export VERSION="$(git describe --tags --long | sed 's/v\(.*\)/\1/')"
             export GO111MODULE=on
             mkdir -p /tmp/logs /tmp/workspace/profiles
 
-            echo "--> Run tests with coverage:"
+            excluded_packages_expr="(okchain/x/.*/client)|(x/simulation)|(x/backend)"
+            included_packages=("./app" "./x/common" "./x/dex" "./x/distribution" "./x/gov" "./x/order" "./x/params" "./x/staking" "./x/token" "./x/upgrade")
+
             for pkg in ${included_packages[@]}; do
-                package_lines=`go list ${pkg}/... | grep -v -E "${excluded_packages_expr}"`
-                echo "${package_lines[@]}"
-                cover_pkgs=`echo ${package_lines[@]} | sed 's/ /,/g'`
-                packages=`echo ${package_lines[@]}`
-                id=`echo "${package_lines}" | head -n 1 | sed 's|[/.]|_|g'`
-                go test -mod=readonly -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -coverpkg=${cover_pkgs} -covermode=atomic  -tags='ledger test_ledger_mock' ${packages} | tee "/tmp/logs/$id-$RANDOM.log"
+              package_lines=`go list ${pkg}/... | grep -v -E "${excluded_packages_expr}"`
+              echo "${package_lines[@]}"
+              cover_pkgs=`echo ${package_lines[@]} | sed 's/ /,/g'`
+              packages=`echo ${package_lines[@]}`
+              id=`echo "${package_lines}" | head -n 1 | sed 's|[/.]|_|g'`
+              go test -mod=readonly -timeout 8m -race -coverprofile=/tmp/workspace/profiles/$id.out -coverpkg=${cover_pkgs} -covermode=atomic  -tags='ledger test_ledger_mock' ${packages} | tee "/tmp/logs/$id-$RANDOM.log"
             done
 
 #            for pkg in $(go list ./... | grep -v -E "${excluded_packages_expr}" | circleci tests split); do


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Description
-----
1.  merge single package tests to multiple-package test to reduce the  running times  consumed in   `go test github.com/okex/okchain/****** `
2. reduce the unittest running time from 3.5 minutes to 2 minutes
3. add `excluded_packages_expr` to skip `go test okchain/x/.*/client` 
4. increase coverage rate from 70% to 82%

-----
- [x] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
