### PR TITLE
FIX: Removing the field MinSelfDelegation from MsgCreateValidator

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -36,7 +36,7 @@ func TestExportAppStateAndValidators_abci_postEndBlocker(t *testing.T) {
 	db := dbm.NewMemDB()
 	logger := log.NewTMLogger(os.Stdout)
 	logger, err := flags.ParseLogLevel("*:error", logger, "error")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer db.Close()
 	app := NewOKChainApp(logger, db, nil, true, 0)
 

--- a/app/genesis/genesis.json
+++ b/app/genesis/genesis.json
@@ -115,10 +115,6 @@
                     "moniker": "node0",
                     "website": ""
                   },
-                  "min_self_delegation": {
-                    "amount": "0.00100000",
-                    "denom": "okt"
-                  },
                   "pubkey": "okchainvalconspub1zcjduepqqxsxcjjletkq40ypzuqz8n925pk0ycw9h8g4saw27adyf2t93szsvpk77u",
                   "validator_address": "okchainvaloper10q0rk5qnyag7wfvvt7rtphlw589m7frs863s3m"
                 }
@@ -130,7 +126,7 @@
                   "type": "tendermint/PubKeySecp256k1",
                   "value": "AgYaL1tZ7ekqvweQhKojG8sDHUfN23qJWviAsTDIWvYU"
                 },
-                "signature": "qT4H9ZUrdQGBcywi6f6GJHN3mu5o5BwJiGlt3KX2Vo0QXIEirwVPKkVnlojWObbq7j1omj4eT1455Tsx8QXXRg=="
+                "signature": "pj6vZdEZOGFMGZ27Q/+lvriFtnoPo6cwy0Slt4j8X6FWtmF0zPxYcJgAwjH1NGRa+6YF38F0SXsn6y/RUjVL6A=="
               }
             ]
           }
@@ -230,7 +226,6 @@
         "max_bonded_validators": 21,
         "max_validators_to_vote": 30,
         "min_delegation": "0.00010000",
-        "min_self_delegation": "0.00100000",
         "unbonding_time": "1209600000000000"
       },
       "proxy_delegator_keys": null,

--- a/cmd/okchaind/testnet.go
+++ b/cmd/okchaind/testnet.go
@@ -201,12 +201,10 @@ func InitTestnet(cmd *cobra.Command, config *tmconfig.Config, cdc *codec.Codec,
 			Coins:   coins,
 		})
 
-		minSelfDelegation := sdk.MustNewDecFromStr("0.001")
 		msg := staking.NewMsgCreateValidator(
 			sdk.ValAddress(addr),
 			valPubKeys[i],
 			staking.NewDescription(nodeDirName, "", "", ""),
-			sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, minSelfDelegation),
 		)
 		kb, err := keys.NewKeyBaseFromDir(clientDir)
 		if err != nil {

--- a/x/distribution/handler_test.go
+++ b/x/distribution/handler_test.go
@@ -20,7 +20,7 @@ func TestHandler(t *testing.T) {
 	// create one validator
 	sh := staking.NewHandler(sk)
 	skMsg := staking.NewMsgCreateValidator(valOpAddrs[0], valConsPks[0],
-		staking.Description{}, keeper.NewTestDecCoin(1, 0))
+		staking.Description{})
 	require.True(t, sh(ctx, skMsg).IsOK())
 
 	//send 100okt fee

--- a/x/distribution/keeper/test_common.go
+++ b/x/distribution/keeper/test_common.go
@@ -108,7 +108,7 @@ func CreateTestInputDefault(t *testing.T, isCheckTx bool, initPower int64) (
 	// create four validators
 	for i := int64(0); i < 4; i++ {
 		msg := staking.NewMsgCreateValidator(valOpAddrs[i], valConsPks[i],
-			staking.Description{}, NewTestDecCoin(i+1, 0))
+			staking.Description{})
 		require.True(t, sh(ctx, msg).IsOK())
 		// assert initial state: zero current rewards
 		require.True(t, dk.GetValidatorAccumulatedCommission(ctx, valOpAddrs[i]).IsZero())

--- a/x/genutil/collect.go
+++ b/x/genutil/collect.go
@@ -145,10 +145,10 @@ func CollectStdTxs(cdc *codec.Codec, moniker, genTxsDir string,
 				"account %v not in genesis.json: %+v", valAddr, addrMap)
 		}
 
-		if delAcc.GetCoins().AmountOf(msg.MinSelfDelegation.Denom).LT(msg.MinSelfDelegation.Amount) {
+		if delAcc.GetCoins().AmountOf(sdk.DefaultBondDenom).LT(stakingtypes.DefaultMinSelfDelegation) {
 			return appGenTxs, persistentPeers, fmt.Errorf(
-				"insufficient fund for delegation %v: %v < %v",
-				delAcc.GetAddress(), delAcc.GetCoins().AmountOf(msg.MinSelfDelegation.Denom), msg.MinSelfDelegation.Amount,
+				"insufficient fund for default min self delegation %v: %v < %v",
+				delAcc.GetAddress(), delAcc.GetCoins().AmountOf(sdk.DefaultBondDenom), stakingtypes.DefaultMinSelfDelegation,
 			)
 		}
 

--- a/x/gov/keeper/test_common.go
+++ b/x/gov/keeper/test_common.go
@@ -81,7 +81,6 @@ func CreateValidators(
 		valCreateMsg := staking.NewMsgCreateValidator(
 			addrs[i], pubkeys[i],
 			testDescription,
-			sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, DefaultMSD),
 		)
 
 		res := stakingHandler(ctx, valCreateMsg)

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -64,10 +64,8 @@ func GetCmdCreateValidator(cdc *codec.Codec) *cobra.Command {
 	}
 
 	cmd.Flags().AddFlagSet(FsPk)
-	//cmd.Flags().AddFlagSet(FsAmount)
 	cmd.Flags().AddFlagSet(fsDescriptionCreate)
-	//cmd.Flags().AddFlagSet(FsCommissionCreate)
-	//cmd.Flags().AddFlagSet(FsMinSelfDelegation)
+
 
 	cmd.Flags().String(FlagIP, "",
 		fmt.Sprintf("The node's public IP. It takes effect only when used in combination with --%s", client.FlagGenerateOnly))

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -130,12 +130,11 @@ func GetCmdEditValidator(cdc *codec.Codec) *cobra.Command {
 //__________________________________________________________
 
 var (
-	//defaultTokens                  = sdk.TokensFromConsensusPower(100)
-	//defaultAmount                  = defaultTokens.String() + sdk.DefaultBondDenom
-	//defaultCommissionRate          = "0.1"
-	//defaultCommissionMaxRate       = "0.2"
-	//defaultCommissionMaxChangeRate = "0.01"
-	defaultMinSelfDelegation = "0.001okt"
+//defaultTokens                  = sdk.TokensFromConsensusPower(100)
+//defaultAmount                  = defaultTokens.String() + sdk.DefaultBondDenom
+//defaultCommissionRate          = "0.1"
+//defaultCommissionMaxRate       = "0.2"
+//defaultCommissionMaxChangeRate = "0.01"
 )
 
 // CreateValidatorMsgHelpers returns the flagset, particular flags, and a description of defaults
@@ -218,17 +217,10 @@ func BuildCreateValidatorMsg(cliCtx context.CLIContext, txBldr auth.TxBuilder) (
 		viper.GetString(FlagDetails),
 	)
 
-	// get the initial validator min self delegation
-	minSelfDelegation, err := sdk.ParseDecCoin(defaultMinSelfDelegation)
-	if err != nil {
-		return txBldr, nil, err
-	}
-
 	msg := types.NewMsgCreateValidator(
 		sdk.ValAddress(valAddr),
 		pk,
 		description,
-		minSelfDelegation,
 	)
 
 	if viper.GetBool(client.FlagGenerateOnly) {

--- a/x/staking/common_test.go
+++ b/x/staking/common_test.go
@@ -134,7 +134,7 @@ func (a createValidatorAction) apply(ctx sdk.Context, expVaStatus IValidatorStat
 	resultCtx.t.Logf("====> Apply createValidatorAction[%d], addr:%s, msd: %s, maxVA: %d\n",
 		ctx.BlockHeight(), val.OperatorAddress, val.MinSelfDelegation, resultCtx.params.MaxValidators)
 
-	msgCreateValidator := NewTestMsgCreateValidator(val.OperatorAddress, val.ConsPubKey, val.MinSelfDelegation)
+	msgCreateValidator := NewTestMsgCreateValidator(val.OperatorAddress, val.ConsPubKey)
 	if err := msgCreateValidator.ValidateBasic(); err != nil {
 		panic(err)
 	}

--- a/x/staking/handler.go
+++ b/x/staking/handler.go
@@ -99,9 +99,6 @@ func handleMsgCreateValidator(ctx sdk.Context, msg types.MsgCreateValidator, k k
 	if _, found := k.GetValidatorByConsAddr(ctx, sdk.GetConsAddress(msg.PubKey)); found {
 		return ErrValidatorPubKeyExists(k.Codespace()).Result()
 	}
-	if msg.MinSelfDelegation.Denom != k.BondDenom(ctx) {
-		return ErrBadDenom(k.Codespace()).Result()
-	}
 
 	if _, err := msg.Description.EnsureLength(); err != nil {
 		return err.Result()
@@ -131,7 +128,7 @@ func handleMsgCreateValidator(ctx sdk.Context, msg types.MsgCreateValidator, k k
 	ctx.EventManager().EmitEvents(sdk.Events{
 		sdk.NewEvent(types.EventTypeCreateValidator,
 			sdk.NewAttribute(types.AttributeKeyValidator, msg.ValidatorAddress.String()),
-			sdk.NewAttribute(sdk.AttributeKeyAmount, msg.MinSelfDelegation.Amount.String())),
+			sdk.NewAttribute(sdk.AttributeKeyAmount, types.DefaultMinSelfDelegation.String())),
 		sdk.NewEvent(sdk.EventTypeMessage,
 			sdk.NewAttribute(sdk.AttributeKeyModule, types.AttributeValueCategory),
 			sdk.NewAttribute(sdk.AttributeKeySender, msg.DelegatorAddress.String())),

--- a/x/staking/handler_test.go
+++ b/x/staking/handler_test.go
@@ -35,7 +35,7 @@ func TestValidatorByPowerIndex(t *testing.T) {
 	_ = setInstantUnbondPeriod(keeper, ctx)
 
 	// create validator
-	msgCreateValidator := NewTestMsgCreateValidator(validatorAddr, keep.PKs[0], DefaultMSD)
+	msgCreateValidator := NewTestMsgCreateValidator(validatorAddr, keep.PKs[0])
 	got := handleMsgCreateValidator(ctx, msgCreateValidator, keeper)
 	require.True(t, got.IsOK(), "expected create-validator to be ok, got %v", got)
 
@@ -50,7 +50,7 @@ func TestValidatorByPowerIndex(t *testing.T) {
 	require.True(t, ValidatorByPowerIndexExists(ctx, mKeeper, power))
 
 	// create a second validator keep it bonded
-	msgCreateValidator = NewTestMsgCreateValidator(validatorAddr2, keep.PKs[2], DefaultMSD)
+	msgCreateValidator = NewTestMsgCreateValidator(validatorAddr2, keep.PKs[2])
 	got = handleMsgCreateValidator(ctx, msgCreateValidator, keeper)
 	require.True(t, got.IsOK(), "expected create-validator to be ok, got %v", got)
 
@@ -77,7 +77,7 @@ func TestDuplicatesMsgCreateValidator(t *testing.T) {
 	addr1, addr2 := sdk.ValAddress(keep.Addrs[0]), sdk.ValAddress(keep.Addrs[1])
 	pk1, pk2 := keep.PKs[0], keep.PKs[1]
 
-	msgCreateValidator1 := NewTestMsgCreateValidator(addr1, pk1, DefaultMSD)
+	msgCreateValidator1 := NewTestMsgCreateValidator(addr1, pk1)
 	got := handleMsgCreateValidator(ctx, msgCreateValidator1, keeper)
 	require.True(t, got.IsOK(), "%v", got)
 
@@ -95,17 +95,17 @@ func TestDuplicatesMsgCreateValidator(t *testing.T) {
 	assert.Equal(t, defaultDescriptionForTest(), validator.Description)
 
 	// two validators can't have the same operator address
-	msgCreateValidator2 := NewTestMsgCreateValidator(addr1, pk2, DefaultMSD)
+	msgCreateValidator2 := NewTestMsgCreateValidator(addr1, pk2)
 	got = handleMsgCreateValidator(ctx, msgCreateValidator2, keeper)
 	require.False(t, got.IsOK(), "%v", got)
 
 	// two validators can't have the same pubkey
-	msgCreateValidator3 := NewTestMsgCreateValidator(addr2, pk1, DefaultMSD)
+	msgCreateValidator3 := NewTestMsgCreateValidator(addr2, pk1)
 	got = handleMsgCreateValidator(ctx, msgCreateValidator3, keeper)
 	require.False(t, got.IsOK(), "%v", got)
 
 	// must have different pubkey and operator
-	msgCreateValidator4 := NewTestMsgCreateValidator(addr2, pk2, DefaultMSD)
+	msgCreateValidator4 := NewTestMsgCreateValidator(addr2, pk2)
 	got = handleMsgCreateValidator(ctx, msgCreateValidator4, keeper)
 	require.True(t, got.IsOK(), "%v", got)
 
@@ -143,7 +143,7 @@ func TestInvalidPubKeyTypeMsgCreateValidator(t *testing.T) {
 	invalidPk := secp256k1.GenPrivKey().PubKey()
 
 	// invalid pukKey type should not be allowed
-	msgCreateValidator := NewTestMsgCreateValidator(addr, invalidPk, DefaultMSD)
+	msgCreateValidator := NewTestMsgCreateValidator(addr, invalidPk)
 	got := handleMsgCreateValidator(ctx, msgCreateValidator, keeper)
 	require.False(t, got.IsOK(), "%v", got)
 
@@ -163,7 +163,7 @@ func TestEditValidatorDecreaseMinSelfDelegation(t *testing.T) {
 	_ = setInstantUnbondPeriod(keeper, ctx)
 
 	// create validator
-	msgCreateValidator := NewTestMsgCreateValidator(validatorAddr, keep.PKs[0], DefaultMSD)
+	msgCreateValidator := NewTestMsgCreateValidator(validatorAddr, keep.PKs[0])
 	handler := NewHandler(keeper)
 	got := handler(ctx, msgCreateValidator)
 	require.True(t, got.IsOK(), "expected create-validator to be ok, got %v", got)

--- a/x/staking/handler_vote_test.go
+++ b/x/staking/handler_vote_test.go
@@ -26,7 +26,7 @@ func TestHandlerDestroyValidator(t *testing.T) {
 
 	//1. create a validator
 	handler = NewHandler(keeper)
-	createValMsg := NewTestMsgCreateValidator(validatorAddr1, pk1, DefaultMSD)
+	createValMsg := NewTestMsgCreateValidator(validatorAddr1, pk1)
 	response := handler(ctx, createValMsg)
 	require.True(t, response.IsOK())
 	updates := keeper.ApplyAndReturnValidatorSetUpdates(ctx)

--- a/x/staking/keeper/test_common.go
+++ b/x/staking/keeper/test_common.go
@@ -276,12 +276,9 @@ func ValidatorByPowerIndexExists(ctx sdk.Context, keeper MockStakingKeeper, powe
 	return store.Has(power)
 }
 
-func NewTestMsgCreateValidator(address sdk.ValAddress, pubKey crypto.PubKey, msdAmt sdk.Dec) types.MsgCreateValidator {
-	msd := sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, msdAmt)
-
+func NewTestMsgCreateValidator(address sdk.ValAddress, pubKey crypto.PubKey) types.MsgCreateValidator {
 	return types.NewMsgCreateValidator(address, pubKey,
-		types.NewDescription("my moniker", "my identity", "my website", "my details"), msd,
-	)
+		types.NewDescription("my moniker", "my identity", "my website", "my details"))
 }
 
 func NewTestMsgDelegate(delAddr sdk.AccAddress, valAddr sdk.ValAddress, amt sdk.Dec) types.MsgDelegate {

--- a/x/staking/types/msg.go
+++ b/x/staking/types/msg.go
@@ -28,10 +28,9 @@ type MsgCreateValidator struct {
 type msgCreateValidatorJSON struct {
 	Description Description `json:"description" yaml:"description"`
 	//Commission        CommissionRates `json:"commission" yaml:"commission"`
-	MinSelfDelegation sdk.DecCoin    `json:"min_self_delegation" yaml:"min_self_delegation"`
-	DelegatorAddress  sdk.AccAddress `json:"delegator_address" yaml:"delegator_address"`
-	ValidatorAddress  sdk.ValAddress `json:"validator_address" yaml:"validator_address"`
-	PubKey            string         `json:"pubkey" yaml:"pubkey"`
+	DelegatorAddress sdk.AccAddress `json:"delegator_address" yaml:"delegator_address"`
+	ValidatorAddress sdk.ValAddress `json:"validator_address" yaml:"validator_address"`
+	PubKey           string         `json:"pubkey" yaml:"pubkey"`
 }
 
 // NewMsgCreateValidator creates a msg of create-validator

--- a/x/staking/types/msg.go
+++ b/x/staking/types/msg.go
@@ -20,10 +20,9 @@ var (
 type MsgCreateValidator struct {
 	Description Description `json:"description" yaml:"description"`
 	//Commission        CommissionRates `json:"commission" yaml:"commission"`
-	MinSelfDelegation sdk.DecCoin    `json:"min_self_delegation" yaml:"min_self_delegation"`
-	DelegatorAddress  sdk.AccAddress `json:"delegator_address" yaml:"delegator_address"`
-	ValidatorAddress  sdk.ValAddress `json:"validator_address" yaml:"validator_address"`
-	PubKey            crypto.PubKey  `json:"pubkey" yaml:"pubkey"`
+	DelegatorAddress sdk.AccAddress `json:"delegator_address" yaml:"delegator_address"`
+	ValidatorAddress sdk.ValAddress `json:"validator_address" yaml:"validator_address"`
+	PubKey           crypto.PubKey  `json:"pubkey" yaml:"pubkey"`
 }
 
 type msgCreateValidatorJSON struct {
@@ -39,15 +38,13 @@ type msgCreateValidatorJSON struct {
 // Delegator address and validator address are the same
 func NewMsgCreateValidator(
 	valAddr sdk.ValAddress, pubKey crypto.PubKey,
-	description Description, minSelfDelegation sdk.DecCoin,
-) MsgCreateValidator {
+	description Description) MsgCreateValidator {
 
 	return MsgCreateValidator{
-		Description:       description,
-		DelegatorAddress:  sdk.AccAddress(valAddr),
-		ValidatorAddress:  valAddr,
-		PubKey:            pubKey,
-		MinSelfDelegation: minSelfDelegation,
+		Description:      description,
+		DelegatorAddress: sdk.AccAddress(valAddr),
+		ValidatorAddress: valAddr,
+		PubKey:           pubKey,
 	}
 }
 
@@ -72,11 +69,10 @@ func (msg MsgCreateValidator) GetSigners() []sdk.AccAddress {
 // MarshalJSON implements the json.Marshaler interface to provide custom JSON serialization
 func (msg MsgCreateValidator) MarshalJSON() ([]byte, error) {
 	return json.Marshal(msgCreateValidatorJSON{
-		Description:       msg.Description,
-		DelegatorAddress:  msg.DelegatorAddress,
-		ValidatorAddress:  msg.ValidatorAddress,
-		PubKey:            sdk.MustBech32ifyConsPub(msg.PubKey),
-		MinSelfDelegation: msg.MinSelfDelegation,
+		Description:      msg.Description,
+		DelegatorAddress: msg.DelegatorAddress,
+		ValidatorAddress: msg.ValidatorAddress,
+		PubKey:           sdk.MustBech32ifyConsPub(msg.PubKey),
 	})
 }
 
@@ -95,7 +91,6 @@ func (msg *MsgCreateValidator) UnmarshalJSON(bz []byte) error {
 	if err != nil {
 		return err
 	}
-	msg.MinSelfDelegation = msgCreateValJSON.MinSelfDelegation
 
 	return nil
 }
@@ -117,9 +112,6 @@ func (msg MsgCreateValidator) ValidateBasic() sdk.Error {
 	}
 	if !sdk.AccAddress(msg.ValidatorAddress).Equals(msg.DelegatorAddress) {
 		return ErrBadValidatorAddr(DefaultCodespace)
-	}
-	if msg.MinSelfDelegation.Amount.LTE(sdk.ZeroDec()) || !msg.MinSelfDelegation.IsValid() {
-		return ErrMinSelfDelegationInvalid(DefaultCodespace)
 	}
 	if msg.Description == (Description{}) {
 		return sdk.NewError(DefaultCodespace, CodeInvalidInput, "description must be included")

--- a/x/staking/types/msg_test.go
+++ b/x/staking/types/msg_test.go
@@ -18,36 +18,31 @@ func TestMsgCreateValidator(t *testing.T) {
 	addr1 := valAddr1
 	tests := []struct {
 		name, moniker, identity, website, details string
-		minSelfDelegation                         sdk.Int
 		validatorAddr                             sdk.ValAddress
 		delegatorAddr                             sdk.AccAddress
 		pubkey                                    crypto.PubKey
 		bond                                      sdk.Coin
 		expectPass                                bool
 	}{
-		{"empty bond", "a", "b", "c", "d", sdk.OneInt(), addr1, dlgAddr1, pk1, coinZero, true},
-		{"zero min self delegation", "a", "b", "c", "d", sdk.ZeroInt(), addr1, dlgAddr1, pk1, coinPos, false},
-		{"basic good", "a", "b", "c", "d", sdk.OneInt(), addr1, dlgAddr1, pk1, coinPos, true},
-		{"partial description", "", "", "c", "", sdk.OneInt(), addr1, dlgAddr1, pk1, coinPos, true},
-		{"empty description", "", "", "", "", sdk.OneInt(), addr1, dlgAddr1, pk1, coinPos, false},
-		{"empty address1", "a", "b", "c", "d", sdk.OneInt(), emptyAddr, dlgAddr1, pk1, coinPos, false},
-		{"empty address2", "a", "b", "c", "d", sdk.OneInt(), nil, nil, pk1, coinPos, false},
-		{"valAddr dlgAddr not equals", "a", "b", "c", "d", sdk.OneInt(), addr1, dlgAddr2, pk1, coinPos, false},
-		{"empty pubkey", "a", "b", "c", "d", sdk.OneInt(), addr1, dlgAddr1, emptyPubkey, coinPos, true},
+		{"empty bond", "a", "b", "c", "d",  addr1, dlgAddr1, pk1, coinZero, true},
+		{"basic good", "a", "b", "c", "d",  addr1, dlgAddr1, pk1, coinPos, true},
+		{"partial description", "", "", "c", "",  addr1, dlgAddr1, pk1, coinPos, true},
+		{"empty description", "", "", "", "",  addr1, dlgAddr1, pk1, coinPos, false},
+		{"empty address1", "a", "b", "c", "d",  emptyAddr, dlgAddr1, pk1, coinPos, false},
+		{"empty address2", "a", "b", "c", "d",  nil, nil, pk1, coinPos, false},
+		{"valAddr dlgAddr not equals", "a", "b", "c", "d", addr1, dlgAddr2, pk1, coinPos, false},
+		{"empty pubkey", "a", "b", "c", "d", addr1, dlgAddr1, emptyPubkey, coinPos, true},
 		//{"negative min self delegation", "a", "b", "c", "d", commission1, sdk.NewInt(-1), addr1, pk1, coinPos, false},
 		//{"delegation less than min self delegation", "a", "b", "c", "d", commission1, coinPos.Amount.Add(sdk.OneInt()), addr1, pk1, coinPos, false},
 	}
 
 	for _, tc := range tests {
 		description := NewDescription(tc.moniker, tc.identity, tc.website, tc.details)
-		coin := sdk.NewDecCoin(sdk.DefaultBondDenom, tc.minSelfDelegation)
-
 		msg := MsgCreateValidator{
 			Description:       description,
 			DelegatorAddress:  tc.delegatorAddr,
 			ValidatorAddress:  tc.validatorAddr,
 			PubKey:            tc.pubkey,
-			MinSelfDelegation: coin,
 		}
 
 		if tc.expectPass {
@@ -82,12 +77,8 @@ func TestMsgDestroyValidator(t *testing.T) {
 }
 
 func TestMsgCreateValidator_Smoke(t *testing.T) {
-
-	msd := sdk.NewDecCoinFromDec(sdk.DefaultBondDenom, sdk.NewDec(2000))
-
 	msg := NewMsgCreateValidator(valAddr1, pk1,
-		NewDescription("my moniker", "my identity", "my website", "my details"), msd,
-	)
+		NewDescription("my moniker", "my identity", "my website", "my details"))
 	require.Contains(t, msg.Route(), RouterKey)
 	require.Contains(t, msg.Type(), "create_validator")
 	require.True(t, len(msg.GetSigners()) == 1, msg)

--- a/x/staking/types/params.go
+++ b/x/staking/types/params.go
@@ -41,7 +41,6 @@ var (
 	KeyTheEndOfLastEpoch = []byte("TheEndOfLastEpoch") // a block height that is the end of last epoch
 
 	KeyMaxValsToVote          = []byte("MaxValsToVote")
-	KeyMinSelfDelegationLimit = []byte("MinSelfDelegationLimit")
 	KeyMinDelegation          = []byte("MinDelegation")
 )
 


### PR DESCRIPTION
Closes: #46 

## Description

Remove the field MinSelfDelegation from MsgCreateValidator and fit the related part in other modules.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
