### PR TITLE
OPTIMIZE: hide the flags related to gas and fees in order cli

### DIFF
--- a/x/order/client/cli/tx.go
+++ b/x/order/client/cli/tx.go
@@ -15,6 +15,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	flagGas = "gas"
+)
+
 // GetTxCmd returns the transaction commands for this module
 func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 	txCmd := &cobra.Command{
@@ -27,6 +31,8 @@ func GetTxCmd(cdc *codec.Codec) *cobra.Command {
 		getCmdCancelOrder(cdc),
 	)...)
 
+	// hide the flags related to gas and fees
+	hideFlagsOnChildCmd(txCmd, client.FlagDryRun, client.FlagFees, client.FlagGasAdjustment, client.FlagGasPrices, flagGas)
 	return txCmd
 }
 
@@ -128,5 +134,15 @@ func getCmdCancelOrder(cdc *codec.Codec) *cobra.Command {
 			}
 			return err
 		},
+	}
+}
+
+func hideFlagsOnChildCmd(cmd *cobra.Command, flagsToHide ...string) {
+	for _, childCmd := range cmd.Commands() {
+		for _, flag := range flagsToHide {
+			if err := childCmd.Flags().MarkHidden(flag); err != nil {
+				panic(err)
+			}
+		}
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Close:  #70 

## Description

Hide the flags related to gas and fees in `okchaincli tx order new/cancel`.

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
