### PR TITLE
fix index out of bounds bug when fill order

### DIFF
--- a/x/order/match/periodicauction/fill.go
+++ b/x/order/match/periodicauction/fill.go
@@ -150,6 +150,10 @@ func fillOrderByKey(ctx sdk.Context, keeper orderkeeper.Keeper, key string,
 
 	index := 0
 	for filledDealsCnt < remainDeals && filledAmount.LT(needFillAmount) {
+		if index >= len(orderIDs){
+			break
+		}
+
 		order := keeper.GetOrder(ctx, orderIDs[index])
 		if filledAmount.Add(order.RemainQuantity).LTE(needFillAmount) {
 			filledAmount = filledAmount.Add(order.RemainQuantity)

--- a/x/order/match/periodicauction/fill.go
+++ b/x/order/match/periodicauction/fill.go
@@ -155,6 +155,11 @@ func fillOrderByKey(ctx sdk.Context, keeper orderkeeper.Keeper, key string,
 		}
 
 		order := keeper.GetOrder(ctx, orderIDs[index])
+		if order == nil {
+			orderIDs = append(orderIDs[:index], orderIDs[index+1:]...)
+			continue
+		}
+
 		if filledAmount.Add(order.RemainQuantity).LTE(needFillAmount) {
 			filledAmount = filledAmount.Add(order.RemainQuantity)
 			deal := fillOrder(order, ctx, keeper, fillPrice, order.RemainQuantity, feeParams)

--- a/x/order/match/periodicauction/match.go
+++ b/x/order/match/periodicauction/match.go
@@ -172,7 +172,7 @@ func expireOrdersInExpiredBlock(ctx sdk.Context, k keeper.Keeper, expiredBlockHe
 	}
 }
 
-func markCurBlockToFeatureExpireBlockList(ctx sdk.Context, keeper keeper.Keeper) {
+func markCurBlockToFutureExpireBlockList(ctx sdk.Context, keeper keeper.Keeper) {
 	curBlockHeight := ctx.BlockHeight()
 	feeParams := keeper.GetParams(ctx)
 
@@ -267,7 +267,7 @@ func cleanOrdersByOrderIDList(ctx sdk.Context, keeper keeper.Keeper, orderIDList
 func cleanupExpiredOrders(ctx sdk.Context, keeper keeper.Keeper) {
 
 	// Look forward to see what height will this block expired
-	markCurBlockToFeatureExpireBlockList(ctx, keeper)
+	markCurBlockToFutureExpireBlockList(ctx, keeper)
 
 	// Clean the expired orders which is collected by the last block
 	cleanLastBlockClosedOrders(ctx, keeper)

--- a/x/order/match/periodicauction/match_test.go
+++ b/x/order/match/periodicauction/match_test.go
@@ -352,7 +352,7 @@ func TestMarkCurBlockToFeatureExpireBlockList(t *testing.T) {
 	ctx := testInput.Ctx
 	feeParams := types.DefaultParams()
 
-	markCurBlockToFeatureExpireBlockList(ctx, keeper)
+	markCurBlockToFutureExpireBlockList(ctx, keeper)
 	expiredBlocks := keeper.GetExpireBlockHeight(ctx, ctx.BlockHeight()+feeParams.OrderExpireBlocks)
 	require.EqualValues(t, 0, expiredBlocks[0])
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
