### PR TITLE
FIX: optimize the error msg when a delegator unbond part of the stake from a destroyed validator

### DIFF
--- a/x/staking/types/errors.go
+++ b/x/staking/types/errors.go
@@ -137,8 +137,8 @@ func ErrNoUnbondingDelegation(codespace sdk.CodespaceType) sdk.Error {
 // ErrVoteDismission returns an error when a zero-msd validator becomes the voting target
 func ErrVoteDismission(codespace sdk.CodespaceType, valAddr string) sdk.Error {
 	return sdk.NewError(codespace, CodeInvalidVote,
-		"failed. validator %s with zero min self delegation isn't allowed to vote. please get rid of it from the "+
-			"voting list by voting other validators again", valAddr)
+		"failed. destroyed validator %s isn't allowed to vote. please get rid of it from the "+
+			"voting list by voting other validators again or unbond all delegated tokens", valAddr)
 }
 
 // ErrNoAvailableValsToVote returns an error when none of the validators in voting list is available to vote


### PR DESCRIPTION
Close: #156 
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
