### PR TITLE
FINISH: add REST param 'all' for the query of all validators

### DIFF
--- a/x/staking/keeper/querier.go
+++ b/x/staking/keeper/querier.go
@@ -2,13 +2,12 @@ package keeper
 
 import (
 	"fmt"
-	"strings"
-
+	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/tendermint/tendermint/crypto"
+	"strings"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 
-	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/okex/okchain/x/staking/types"
@@ -75,19 +74,24 @@ func queryValidators(ctx sdk.Context, req abci.RequestQuery, k Keeper) ([]byte, 
 	}
 
 	validators := k.GetAllValidators(ctx)
-	filteredVals := make([]types.Validator, 0, len(validators))
 
-	for _, val := range validators {
-		if strings.EqualFold(val.GetStatus().String(), params.Status) {
-			filteredVals = append(filteredVals, val)
-		}
-	}
-
-	start, end := client.Paginate(len(filteredVals), params.Page, params.Limit, int(k.GetParams(ctx).MaxValidators))
-	if start < 0 || end < 0 {
-		filteredVals = []types.Validator{}
+	var filteredVals []types.Validator
+	if params.Status == "all" {
+		filteredVals = validators
 	} else {
-		filteredVals = filteredVals[start:end]
+		filteredVals = make([]types.Validator, 0, len(validators))
+		for _, val := range validators {
+			if strings.EqualFold(val.GetStatus().String(), params.Status) {
+				filteredVals = append(filteredVals, val)
+			}
+		}
+
+		start, end := client.Paginate(len(filteredVals), params.Page, params.Limit, int(k.GetParams(ctx).MaxValidators))
+		if start < 0 || end < 0 {
+			filteredVals = []types.Validator{}
+		} else {
+			filteredVals = filteredVals[start:end]
+		}
 	}
 
 	res, err := codec.MarshalJSONIndent(types.ModuleCdc, filteredVals)


### PR DESCRIPTION
Close: #166 

## Description

Support the REST param - "all" to get all validators info back.

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
