### PR TITLE
Restrict the use of placing or cancelling order in the message array

### DIFF
--- a/app/protocol/protocol_v0.go
+++ b/app/protocol/protocol_v0.go
@@ -480,10 +480,16 @@ func validateMsgHook(orderKeeper order.Keeper) auth.ValidateMsgHandler {
 			switch assertedMsg := msg.(type) {
 			case order.MsgNewOrders:
 				hasNewOrCancelOrdersMsg = true
-				return order.ValidateMsgNewOrders(newCtx, orderKeeper, assertedMsg)
+				result := order.ValidateMsgNewOrders(newCtx, orderKeeper, assertedMsg)
+				if !result.IsOK() {
+					return result
+				}
 			case order.MsgCancelOrders:
 				hasNewOrCancelOrdersMsg = true
-				return order.ValidateMsgCancelOrders(newCtx, orderKeeper, assertedMsg)
+				result := order.ValidateMsgCancelOrders(newCtx, orderKeeper, assertedMsg)
+				if !result.IsOK() {
+					return result
+				}
 			}
 		}
 		if len(msgs) > 1 && hasNewOrCancelOrdersMsg {


### PR DESCRIPTION
It is not expected that msgs with placeOrder type or cancelOrder type in the msg array

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

- Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/okex/okchain/blob/develop/CONTRIBUTING.md#pr-targeting))

- [ ] Linked to github-issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote tests
- [ ] Updated relevant documentation (`docs/`)
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Reviewed `Files changed` in the github PR explorer

______

For Admin Use:
- Added appropriate labels to PR (ex. wip, ready-for-review, docs)
- Reviewers Assigned
- Squashed all commits, uses message "Merge PR #XYZ: [title]" ([coding standards](https://github.com/okex/coding/blob/master/README.md#merging-a-pr))
